### PR TITLE
Fix NSInternalInconsistencyError error on launch

### DIFF
--- a/ios/media/coreimage/adjust_contrast_and_brightness_of_an_image/color_controls/AppDelegate.cs
+++ b/ios/media/coreimage/adjust_contrast_and_brightness_of_an_image/color_controls/AppDelegate.cs
@@ -41,12 +41,11 @@ namespace ColorControl {
 			navigationController = new UINavigationController();
 			navigationController.PushViewController (viewController, false);
 
-			// If you have defined a view, add it here:
-			window.AddSubview (navigationController.View);
-			
+			window.RootViewController = navigationController;
+
 			// make the window visible
 			window.MakeKeyAndVisible ();
-			
+
 			return true;
 		}
 	}

--- a/ios/media/coreimage/adjust_contrast_and_brightness_of_an_image/color_controls_pro/AppDelegate.cs
+++ b/ios/media/coreimage/adjust_contrast_and_brightness_of_an_image/color_controls_pro/AppDelegate.cs
@@ -41,8 +41,7 @@ namespace ColorControl {
 			navigationController = new UINavigationController();
 			navigationController.PushViewController (viewController, false);
 
-			// If you have defined a view, add it here:
-			window.AddSubview (navigationController.View);
+			window.RootViewController = navigationController;
 			
 			// make the window visible
 			window.MakeKeyAndVisible ();


### PR DESCRIPTION
The CoreImage samples were not setting the `RootViewController` which causes an `NSInternalInconsistencyError`