### PR TITLE
Updated Microphone Permissions for iOS 10

### DIFF
--- a/ios/media/sound/record_sound/Info.plist
+++ b/ios/media/sound/record_sound/Info.plist
@@ -43,5 +43,7 @@
 	</array>
 	<key>XSAppIconAssets</key>
 	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>This app needs to use your microphone.</string>
 </dict>
 </plist>


### PR DESCRIPTION
I added an NSUsageDescription to the info.plist for the sample sounds test recipe. Without this change the test app will silently fail on iOS 10. Can you also updated the documentation with a note about the requirements for permissions on iOS 10? I spent the better part of a day looking into various solutions before stumbling onto this blog post https://blog.xamarin.com/new-ios-10-privacy-permission-settings/