### PR TITLE
MapView: Updated ViewControllers to set root, fixed UISelectionBar

### DIFF
--- a/ios/content_controls/map_view/add_an_annotation_to_a_map/Add_an_Annotation/MapViewController.cs
+++ b/ios/content_controls/map_view/add_an_annotation_to_a_map/Add_an_Annotation/MapViewController.cs
@@ -22,7 +22,7 @@ namespace MapView {
 			mapView.AutoresizingMask = UIViewAutoresizing.FlexibleDimensions;
 			View.AddSubview(mapView);
 			
-			// create our location and zoom for los angeles
+			// create our location and zoom for Paris
 			var coords = new CLLocationCoordinate2D(48.857, 2.351); // paris
 			var span = new MKCoordinateSpan(MilesToLatitudeDegrees (2), MilesToLongitudeDegrees (2, coords.Latitude));
 
@@ -37,7 +37,11 @@ namespace MapView {
 			#region Not related to this sample
 			int typesWidth=260, typesHeight=30, distanceFromBottom=60;
 			mapTypes = new UISegmentedControl(new CGRect((View.Bounds.Width-typesWidth)/2, View.Bounds.Height-distanceFromBottom, typesWidth, typesHeight));
-			mapTypes.InsertSegment("Road", 0, false);
+            mapTypes.BackgroundColor = UIColor.White;
+            mapTypes.BackgroundColor = UIColor.White;
+            mapTypes.Layer.CornerRadius = 5;
+            mapTypes.ClipsToBounds = true;
+            mapTypes.InsertSegment("Road", 0, false);
 			mapTypes.InsertSegment("Satellite", 1, false);
 			mapTypes.InsertSegment("Hybrid", 2, false);
 			mapTypes.SelectedSegment = 0; // Road is the default

--- a/ios/content_controls/map_view/add_an_overlay_to_a_map/AppDelegate.cs
+++ b/ios/content_controls/map_view/add_an_overlay_to_a_map/AppDelegate.cs
@@ -34,7 +34,7 @@ namespace MapView {
 			navigationController.PushViewController (viewController, false);
 
 			// If you have defined a view, add it here:
-			window.AddSubview (navigationController.View);
+            window.RootViewController = navigationController;
 			
 			// make the window visible
 			window.MakeKeyAndVisible ();

--- a/ios/content_controls/map_view/add_an_overlay_to_a_map/MapViewController.cs
+++ b/ios/content_controls/map_view/add_an_overlay_to_a_map/MapViewController.cs
@@ -46,7 +46,10 @@ namespace MapView {
 			#region Not related to this sample
 			int typesWidth=260, typesHeight=30, distanceFromBottom=60;
 			mapTypes = new UISegmentedControl(new CGRect((View.Bounds.Width-typesWidth)/2, View.Bounds.Height-distanceFromBottom, typesWidth, typesHeight));
-			mapTypes.InsertSegment("Road", 0, false);
+            mapTypes.BackgroundColor = UIColor.White;
+            mapTypes.Layer.CornerRadius = 5;
+            mapTypes.ClipsToBounds = true;
+            mapTypes.InsertSegment("Road", 0, false);
 			mapTypes.InsertSegment("Satellite", 1, false);
 			mapTypes.InsertSegment("Hybrid", 2, false);
 			mapTypes.SelectedSegment = 1; // Road is the default

--- a/ios/content_controls/map_view/change_map_modes/AppDelegate.cs
+++ b/ios/content_controls/map_view/change_map_modes/AppDelegate.cs
@@ -34,7 +34,7 @@ namespace MapView {
 			navigationController.PushViewController (viewController, false);
 
 			// If you have defined a view, add it here:
-			window.AddSubview (navigationController.View);
+            window.RootViewController = navigationController;
 			
 			// make the window visible
 			window.MakeKeyAndVisible ();

--- a/ios/content_controls/map_view/change_map_modes/MapViewController.cs
+++ b/ios/content_controls/map_view/change_map_modes/MapViewController.cs
@@ -26,6 +26,9 @@ namespace MapView {
 
 			int typesWidth=260, typesHeight=30, distanceFromBottom=60;
 			mapTypes = new UISegmentedControl(new CGRect((View.Bounds.Width-typesWidth)/2, View.Bounds.Height-distanceFromBottom, typesWidth, typesHeight));
+            mapTypes.BackgroundColor = UIColor.White;
+            mapTypes.Layer.CornerRadius = 5;
+            mapTypes.ClipsToBounds = true;
 			mapTypes.InsertSegment("Road", 0, false);
 			mapTypes.InsertSegment("Satellite", 1, false);
 			mapTypes.InsertSegment("Hybrid", 2, false);

--- a/ios/content_controls/map_view/display_a_location/AppDelegate.cs
+++ b/ios/content_controls/map_view/display_a_location/AppDelegate.cs
@@ -34,7 +34,7 @@ namespace MapView {
 			navigationController.PushViewController (viewController, false);
 
 			// If you have defined a view, add it here:
-			window.AddSubview (navigationController.View);
+            window.RootViewController = navigationController;
 			
 			// make the window visible
 			window.MakeKeyAndVisible ();

--- a/ios/content_controls/map_view/display_device_location/AppDelegate.cs
+++ b/ios/content_controls/map_view/display_device_location/AppDelegate.cs
@@ -34,7 +34,7 @@ namespace MapView {
 			navigationController.PushViewController (viewController, false);
 
 			// If you have defined a view, add it here:
-			window.AddSubview (navigationController.View);
+            window.RootViewController = navigationController;
 			
 			// make the window visible
 			window.MakeKeyAndVisible ();

--- a/ios/content_controls/map_view/display_device_location/MapViewController.cs
+++ b/ios/content_controls/map_view/display_device_location/MapViewController.cs
@@ -52,7 +52,10 @@ namespace MapView {
 
 			int typesWidth=260, typesHeight=30, distanceFromBottom=60;
 			mapTypes = new UISegmentedControl(new CGRect((View.Bounds.Width-typesWidth)/2, View.Bounds.Height-distanceFromBottom, typesWidth, typesHeight));
-			mapTypes.InsertSegment("Road", 0, false);
+            mapTypes.BackgroundColor = UIColor.White;
+            mapTypes.Layer.CornerRadius = 5;
+            mapTypes.ClipsToBounds = true;
+            mapTypes.InsertSegment("Road", 0, false);
 			mapTypes.InsertSegment("Satellite", 1, false);
 			mapTypes.InsertSegment("Hybrid", 2, false);
 			mapTypes.SelectedSegment = 0; // Road is the default

--- a/ios/content_controls/map_view/handle_annotation_click/AppDelegate.cs
+++ b/ios/content_controls/map_view/handle_annotation_click/AppDelegate.cs
@@ -34,7 +34,7 @@ namespace MapView {
 			navigationController.PushViewController (viewController, false);
 
 			// If you have defined a view, add it here:
-			window.AddSubview (navigationController.View);
+            window.RootViewController = navigationController;
 			
 			// make the window visible
 			window.MakeKeyAndVisible ();

--- a/ios/content_controls/map_view/handle_annotation_click/MapViewController.cs
+++ b/ios/content_controls/map_view/handle_annotation_click/MapViewController.cs
@@ -40,7 +40,11 @@ namespace MapView {
 			#region Not related to this sample
 			int typesWidth=260, typesHeight=30, distanceFromBottom=60;
 			mapTypes = new UISegmentedControl(new CGRect((View.Bounds.Width-typesWidth)/2, View.Bounds.Height-distanceFromBottom, typesWidth, typesHeight));
-			mapTypes.InsertSegment("Road", 0, false);
+            mapTypes = new UISegmentedControl(new CGRect((View.Bounds.Width - typesWidth) / 2, View.Bounds.Height - distanceFromBottom, typesWidth, typesHeight));
+            mapTypes.BackgroundColor = UIColor.White;
+            mapTypes.Layer.CornerRadius = 5;
+            mapTypes.ClipsToBounds = true;
+            mapTypes.InsertSegment("Road", 0, false);
 			mapTypes.InsertSegment("Satellite", 1, false);
 			mapTypes.InsertSegment("Hybrid", 2, false);
 			mapTypes.SelectedSegment = 0; // Road is the default


### PR DESCRIPTION
Updated viewcontrollers to set the root controller, rather than merely add a subview, as is required in iOS 11 (and some previous versions). Gave the selection bar a white background for legibility.