### PR TITLE
[Android Audio Record] : Explicit permissions for post-M; change path…

### DIFF
--- a/android/media/audio/record_audio/RecordAudio/Activity1.cs
+++ b/android/media/audio/record_audio/RecordAudio/Activity1.cs
@@ -8,6 +8,7 @@ using Android.Widget;
 using Android.OS;
 using Android.Media;
 using System.IO;
+using Android;
 
 namespace RecordAudio
 {
@@ -28,7 +29,17 @@ namespace RecordAudio
             _start = FindViewById<Button> (Resource.Id.start);
             _stop = FindViewById<Button> (Resource.Id.stop);
                     
-            string path = "/sdcard/test.3gpp";
+			string path = $"{Android.OS.Environment.ExternalStorageDirectory.AbsolutePath}/test.3gpp";
+
+			//Explicit permissions
+			if (Build.VERSION.SdkInt > BuildVersionCodes.M)
+			{
+				if (CheckSelfPermission(Manifest.Permission.WriteExternalStorage) != Android.Content.PM.Permission.Granted
+				|| CheckSelfPermission(Manifest.Permission.RecordAudio) != Android.Content.PM.Permission.Granted)
+				{
+					RequestPermissions(new[] { Manifest.Permission.WriteExternalStorage, Manifest.Permission.RecordAudio }, 0);
+				}
+			}
          
             _start.Click += delegate {
                 _stop.Enabled = !_stop.Enabled;

--- a/android/media/audio/record_audio/RecordAudio/Properties/AndroidManifest.xml
+++ b/android/media/audio/record_audio/RecordAudio/Properties/AndroidManifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="RecordAudio.RecordAudio">
-	<application android:label="RecordAudio">
-	</application>
-	<uses-sdk />
+	<application android:label="RecordAudio"></application>
+	<uses-sdk android:minSdkVersion="24" android:targetSdkVersion="24" />
 	<uses-permission android:name="android.permission.RECORD_AUDIO" />
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>


### PR DESCRIPTION
… per Environment

Closes https://github.com/xamarin/recipes/issues/54

Explicit permissions for post-M builds. Uses `Android.OS.Environment.ExternalStorageDirectory` rather than hard-coded `/sdcard/`